### PR TITLE
Update Whitelist Name to Reflect Changes in background.js

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -16,7 +16,7 @@
         "description": "Context menu item"
     },
     "action_whitelist_domain": {
-        "message": "Whitelist this tab's domain",
+        "message": "Add/Remove tab from Whitelist",
         "description": "Context menu item"
     },
     "action_perm_disable": {


### PR DESCRIPTION
I changed the name of the whitelist button in the context menu to make it clearer that it would toggle the tab's domain in the whitelist.  I don't know if there's a way to have it say "Add tab to Whitelist" if it's not already in the whitelist and "Remove tab from Whitelist" if it is, but if you know of a way to do that and you have the time, that would probably be ideal.