### PR TITLE
Add Ability to Remove from Whitelist in Context Menu

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -153,6 +153,14 @@ chrome.contextMenus.create({
             settings.set("whitelist_domains", list);
             chrome.tabs.reload(tab.id);
         }
+        else { // If the domain is already in the list, remove it
+            list = list.slice();
+            var index = list.indexOf(domain);
+            if (index === -1) { return; } // this is probably redundant...
+            list.splice(index, 1);
+            settings.set("whitelist_domains", list);
+            chrome.tabs.reload(tab.id);
+        }
     }
 });
 


### PR DESCRIPTION
In the context menu, if the user clicks the whitelist button and the domain is already in the whitelist, it will remove it.  This (along with changing the name of the context menu button) will provide a much easier and much faster method of removing websites from the whitelist, a feature that at least I would use a lot (I often used that feature in another image blocker), and I'm sure others would benefit from it as well.

PS.  This is my first time committing to a GitHub repository and my first time working on an extension, so please let me know if I'm doing anything wrong.  I've only tested it in Chromium on Linux, but it's simple enough that it should work on other browsers/systems.